### PR TITLE
Sets Default for Schema Encoding

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,7 @@ variable "schema" {
 }
 
 variable "schema_encoding" {
+  default     = "ENCODING_UNSPECIFIED"
   description = "The encoding of messages validated against schema. Default value is ENCODING_UNSPECIFIED. Possible values are: ENCODING_UNSPECIFIED, JSON, BINARY."
   type        = string
 


### PR DESCRIPTION
Sets the default value for `schema_encoding` to limit the amount of required variables.
