### PR TITLE
chore(terraform): relax google provider constraint for pubsub module compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.5.0"
+      version = ">= 6.5.0, < 8.0.0"
     }
   }
 }


### PR DESCRIPTION
Update the pubsub module to declare a minimum required Google provider
version (>= 6.5.0) while allowing newer compatible major versions (< 8.0.0).

This prevents provider version conflicts when the module is used alongside
other modules that pin to the Google v7 provider in root configurations.
