### PR TITLE
feat: add create_dataset flag to bigquery_config

### DIFF
--- a/modules/topic-schema/outputs.tf
+++ b/modules/topic-schema/outputs.tf
@@ -43,7 +43,7 @@ output "schema_name" {
 
 output "bigquery_dataset_id" {
   description = "The ID of the BigQuery dataset. Null if BigQuery streaming is not enabled."
-  value       = length(google_bigquery_dataset.dataset) > 0 ? google_bigquery_dataset.dataset[0].dataset_id : null
+  value       = local.bigquery_enabled ? local.resolved_dataset_id : null
 }
 
 output "bigquery_table_id" {

--- a/modules/topic-schema/resources.tf
+++ b/modules/topic-schema/resources.tf
@@ -55,11 +55,13 @@ resource "google_pubsub_topic" "topic" {
 
 locals {
   bigquery_enabled       = var.bigquery_config != null
+  create_dataset         = local.bigquery_enabled && var.bigquery_config.create_dataset
   subscription_labels    = var.bigquery_subscription_labels != null ? var.bigquery_subscription_labels : var.labels
   subscription_name      = "${var.topic_name}_BigQuery"
   dead_letter_name       = "${var.topic_name}_DeadLetter"
   pubsub_service_account = var.project_number != null ? "service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com" : null
   bigquery_table_ref     = local.bigquery_enabled ? "${google_pubsub_topic.topic.project}.${var.bigquery_config.dataset_id}.${var.bigquery_config.table_id}" : null
+  resolved_dataset_id    = local.create_dataset ? google_bigquery_dataset.dataset[0].dataset_id : var.bigquery_config.dataset_id
 }
 
 # Fetch the BigQuery schema from GitHub
@@ -70,9 +72,9 @@ data "github_repository_file" "bigquery_schema" {
   file       = var.bigquery_config.schema_path
 }
 
-# BigQuery Dataset
+# BigQuery Dataset (only created when create_dataset is true; set to false for shared datasets)
 resource "google_bigquery_dataset" "dataset" {
-  count       = local.bigquery_enabled ? 1 : 0
+  count       = local.create_dataset ? 1 : 0
   dataset_id  = var.bigquery_config.dataset_id
   project     = google_pubsub_topic.topic.project
   location    = var.bigquery_config.dataset_location
@@ -83,7 +85,7 @@ resource "google_bigquery_dataset" "dataset" {
 # BigQuery Table
 resource "google_bigquery_table" "table" {
   count               = local.bigquery_enabled ? 1 : 0
-  dataset_id          = google_bigquery_dataset.dataset[0].dataset_id
+  dataset_id          = local.resolved_dataset_id
   table_id            = var.bigquery_config.table_id
   project             = google_pubsub_topic.topic.project
   labels              = local.subscription_labels

--- a/modules/topic-schema/variables.tf
+++ b/modules/topic-schema/variables.tf
@@ -75,6 +75,7 @@ variable "bigquery_config" {
     schema_path       = string # Path in schema repo, e.g., "bq/gen/listing_event/v1/raw_listing_event.schema"
     partition_field   = optional(string, null)
     clustering_fields = optional(list(string), [])
+    create_dataset    = optional(bool, true) # Set to false to reference an existing dataset instead of creating one
   })
   default = null
 }


### PR DESCRIPTION
## Summary

When multiple Pub/Sub topics share the same BigQuery dataset, the second module instance fails with `409 Already Exists` because each module tries to create the dataset. Adding `create_dataset = optional(bool, true)` to `bigquery_config` lets consumers set it to `false` to reference an existing dataset.

Usage:
```hcl
bigquery_config = {
  dataset_id      = "marketplace_listing"
  table_id        = "activated_listing_event_v1"
  schema_path     = "bq/gen/listing_event/v1/activated_listing_event.schema"
  create_dataset  = false  # dataset already created by raw listing event module
}
```

Backward compatible — defaults to `true`.

---
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>