### PR TITLE
fix: guard resolved_dataset_id against null bigquery_config

### DIFF
--- a/modules/topic-schema/resources.tf
+++ b/modules/topic-schema/resources.tf
@@ -61,7 +61,7 @@ locals {
   dead_letter_name       = "${var.topic_name}_DeadLetter"
   pubsub_service_account = var.project_number != null ? "service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com" : null
   bigquery_table_ref     = local.bigquery_enabled ? "${google_pubsub_topic.topic.project}.${var.bigquery_config.dataset_id}.${var.bigquery_config.table_id}" : null
-  resolved_dataset_id    = local.create_dataset ? google_bigquery_dataset.dataset[0].dataset_id : var.bigquery_config.dataset_id
+  resolved_dataset_id    = local.bigquery_enabled ? (local.create_dataset ? google_bigquery_dataset.dataset[0].dataset_id : var.bigquery_config.dataset_id) : null
 }
 
 # Fetch the BigQuery schema from GitHub


### PR DESCRIPTION
`modules/topic-schema/resources.tf:64` dereferenced `var.bigquery_config.dataset_id` in the else branch of the ternary unconditionally. Terraform evaluates both ternary branches, so the `create_dataset` guard didn't protect callers that left `bigquery_config = null` (pub/sub topic only, no BigQuery streaming).

Symptom in the wild: `messages-ps-fraud-detection` deploys blocked by `Attempt to get attribute from null value` on Terraform Plan. Every deploy attempt hits this, independent of the app code in the PR.

Fix: guard `resolved_dataset_id` with `local.bigquery_enabled`, matching the pattern already used by sibling locals (`bigquery_enabled`, `create_dataset`, `bigquery_table_ref`). `resolved_dataset_id` is only consumed by `google_bigquery_table.table`, which already gates on `bigquery_enabled` via `count`, so null is safe when BQ isn't configured.

`terraform validate` passes on the module.

[sc-366753]

Co-authored-by: Claude <noreply@anthropic.com>