### PR TITLE
fix: scope pubsub BigQuery IAM to table level

### DIFF
--- a/modules/topic-schema/resources.tf
+++ b/modules/topic-schema/resources.tf
@@ -123,8 +123,8 @@ resource "google_pubsub_subscription" "bigquery" {
   depends_on = [
     google_bigquery_table.table,
     google_pubsub_topic_iam_member.dead_letter_publisher,
-    google_project_iam_member.bigquery_metadata_viewer,
-    google_project_iam_member.bigquery_data_editor
+    google_bigquery_table_iam_member.bigquery_metadata_viewer,
+    google_bigquery_table_iam_member.bigquery_data_editor
   ]
 }
 
@@ -165,18 +165,26 @@ resource "google_pubsub_subscription_iam_member" "bigquery_subscriber" {
   member       = "serviceAccount:${local.pubsub_service_account}"
 }
 
-# IAM: Allow Pub/Sub to read BigQuery table metadata
-resource "google_project_iam_member" "bigquery_metadata_viewer" {
-  count   = local.bigquery_enabled ? 1 : 0
-  project = google_pubsub_topic.topic.project
-  role    = "roles/bigquery.metadataViewer"
-  member  = "serviceAccount:${local.pubsub_service_account}"
+# IAM: Allow Pub/Sub to read BigQuery table metadata.
+# Scoped to the single target table — the service account should not have
+# metadata access to unrelated datasets in the project.
+resource "google_bigquery_table_iam_member" "bigquery_metadata_viewer" {
+  count      = local.bigquery_enabled ? 1 : 0
+  project    = google_bigquery_table.table[0].project
+  dataset_id = google_bigquery_table.table[0].dataset_id
+  table_id   = google_bigquery_table.table[0].table_id
+  role       = "roles/bigquery.metadataViewer"
+  member     = "serviceAccount:${local.pubsub_service_account}"
 }
 
-# IAM: Allow Pub/Sub to write to BigQuery table
-resource "google_project_iam_member" "bigquery_data_editor" {
-  count   = local.bigquery_enabled ? 1 : 0
-  project = google_pubsub_topic.topic.project
-  role    = "roles/bigquery.dataEditor"
-  member  = "serviceAccount:${local.pubsub_service_account}"
+# IAM: Allow Pub/Sub to write to the BigQuery table.
+# Scoped to the single target table — the service account should not have
+# write access to unrelated datasets in the project.
+resource "google_bigquery_table_iam_member" "bigquery_data_editor" {
+  count      = local.bigquery_enabled ? 1 : 0
+  project    = google_bigquery_table.table[0].project
+  dataset_id = google_bigquery_table.table[0].dataset_id
+  table_id   = google_bigquery_table.table[0].table_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${local.pubsub_service_account}"
 }


### PR DESCRIPTION
The module granted the Pub/Sub service account `roles/bigquery.metadataViewer` and `roles/bigquery.dataEditor` at **project** scope via `google_project_iam_member`, giving it read-metadata and write-data on every BigQuery dataset/table in the project. The service account only needs those roles on the one target table.

Same over-permissioning was previously fixed in the sibling subscription module ([terraform-google-ddm-pubsub-subscription PR #13](https://github.com/deseretdigital/terraform-google-ddm-pubsub-subscription/pull/13), commit `f67b9566`). Applying the same pattern here: `google_project_iam_member` → `google_bigquery_table_iam_member`, scoped via `dataset_id` + `table_id` pulled from the created table resource.

`depends_on` on `google_pubsub_subscription.bigquery` updated to reference the new IAM resource names so the table-ready-before-subscription ordering is preserved.

`terraform validate` passes on the module.

[sc-366753]

Co-authored-by: Claude <noreply@anthropic.com>